### PR TITLE
use  ./*glob* so names with dashes won't become options (shellcheck)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-sudo cp *.py /opt/schoolscripts
+sudo cp ./*.py /opt/schoolscripts
 echo "If this is a fresh install, move the .json files from the json folder into ~/.school"


### PR DESCRIPTION
This is just to make your code safer so in case some of your python files have dashes in their name the shell won't accidentally interpret them as options.